### PR TITLE
Adjustments to date normalisation

### DIFF
--- a/src/main/java/eu/europeana/normalization/dates/extraction/extractors/CenturyNumericDateExtractor.java
+++ b/src/main/java/eu/europeana/normalization/dates/extraction/extractors/CenturyNumericDateExtractor.java
@@ -28,7 +28,7 @@ import java.util.regex.Pattern;
 public class CenturyNumericDateExtractor extends AbstractDateExtractor {
 
   private static final String NUMERIC_10_TO_21_ENDING_DOTS_REGEX = "(1\\d|2[0-1])\\.{2}";
-  private static final String NUMERIC_1_TO_21_SUFFIXED_REGEX = "(2?1st|2nd|3rd|(?:1\\d|[4-9]|20)th)\\scentury";
+  private static final String NUMERIC_1_TO_21_SUFFIXED_REGEX = "(2?1(:?st)?|2(:?nd)?|3(:?rd)?|(?:1\\d|[4-9]|20)(:?th)?)\\scentury";
 
   private enum CenturyNumericDatePattern {
     PATTERN_YYYY(
@@ -36,8 +36,10 @@ public class CenturyNumericDateExtractor extends AbstractDateExtractor {
             CASE_INSENSITIVE),
         Integer::parseInt, DateNormalizationExtractorMatchId.CENTURY_NUMERIC),
     PATTERN_ENGLISH(
-        compile(OPTIONAL_QUESTION_MARK_REGEX + NUMERIC_1_TO_21_SUFFIXED_REGEX + OPTIONAL_QUESTION_MARK_REGEX, CASE_INSENSITIVE),
-        century -> (Integer.parseInt(century.substring(0, century.length() - 2)) - 1),
+        compile(OPTIONAL_QUESTION_MARK_REGEX + NUMERIC_1_TO_21_SUFFIXED_REGEX + OPTIONAL_QUESTION_MARK_REGEX,
+            CASE_INSENSITIVE),
+        century -> ((century.length() <= 2 ? Integer.parseInt(century)
+            : Integer.parseInt(century.substring(0, century.length() - 2))) - 1),
         DateNormalizationExtractorMatchId.CENTURY_NUMERIC);
 
     private final Pattern pattern;

--- a/src/main/java/eu/europeana/normalization/normalizers/DatesNormalizer.java
+++ b/src/main/java/eu/europeana/normalization/normalizers/DatesNormalizer.java
@@ -105,9 +105,8 @@ public class DatesNormalizer implements RecordNormalizeAction {
       Namespace.DC.getElement("subject"));
 
   private static final List<Pair<Namespace.Element, XpathQuery>> DATE_PROPERTY_FIELDS = List.of(
-      PROXY_QUERY_CREATED, PROXY_QUERY_ISSUED, PROXY_QUERY_TEMPORAL, PROXY_QUERY_DATE);
-  private static final List<Pair<Namespace.Element, XpathQuery>> GENERIC_PROPERTY_FIELDS = List.of(
-      PROXY_QUERY_COVERAGE, PROXY_QUERY_SUBJECT);
+      PROXY_QUERY_CREATED, PROXY_QUERY_ISSUED, PROXY_QUERY_TEMPORAL, PROXY_QUERY_DATE, PROXY_QUERY_COVERAGE);
+  private static final List<Pair<Namespace.Element, XpathQuery>> GENERIC_PROPERTY_FIELDS = List.of(PROXY_QUERY_SUBJECT);
 
   private static final XpathQuery EUROPEANA_PROXY = new XpathQuery("/%s/%s[%s='true']",
       XpathQuery.RDF_TAG, ORE_PROXY, EDM_EUROPEANA_PROXY);


### PR DESCRIPTION
- dc:coverage is now processed like the other date properties.
- The pattern for century strings in English ("17th century") now matches values that omit the ordinal suffix (for example, "17 century)"